### PR TITLE
Display file path on compilation error

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -123,7 +123,13 @@ define(['CoffeeScript'], function (CoffeeScript) {
             fetchText(path, function (text) {
 
                 //Do CoffeeScript transform.
-                text = CoffeeScript.compile(text, config.CoffeeScript);
+                try {
+                  text = CoffeeScript.compile(text, config.CoffeeScript);
+                }
+                catch (err) {
+                  err.message = "In " + path + ", " + err.message;
+                  throw(err);
+                }
 
                 //Hold on to the transformed text if a build.
                 if (config.isBuild) {


### PR DESCRIPTION
Right now, if a coffeescript file has a syntax error the only error displayed in firebug is not really helpfull if we are loading dozen of cs files.

```
Uncaught Error: Parse error on line 13: Unexpected '{'                 coffee-script.js:4943
```

With the proposed solution it becomes:

```
Uncaught Error: In scripts/threenodes/models/Field.coffee, Parse error on line 13: Unexpected '{'                 cs.js:131
```
