### PR TITLE
Add @cc_on for IE

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -140,7 +140,8 @@ define(['coffee-script'], function (CoffeeScript) {
 
                 //IE with conditional comments on cannot handle the
                 //sourceURL trick, so skip it if enabled.
-                /*@if (@_jscript) @else @*/
+                /*@cc_on
+                @if (@_jscript) @else @*/
                 if (!config.isBuild) {
                     text += "\r\n//@ sourceURL=" + path;
                 }


### PR DESCRIPTION
Without this compilation comment IE don't understand this expression

   /_@if (@_jscript) @else @_/
