### PR TITLE
Require-inline support

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -55,7 +55,7 @@ define(['coffee-script'], function (CoffeeScript) {
 
         fetchText = function (url, callback) {
             var xhr = getXhr();
-            xhr.open('GET', url, true);
+            xhr.open('GET', url, requirejs.inlineRequire ? false : true);
             xhr.onreadystatechange = function (evt) {
                 //Do not explicitly handle errors, those should be
                 //visible via console output in the browser.


### PR DESCRIPTION
This is a hopeful pull request. My expectation is to be shot down briskly. But since this is the core of my workflow right now I need to give it a go.

Basically, I'm using [require-inline](https://github.com/guybedford/require-inline) to sync download progressive enhancement dependencies that are critical for the current point in the page load. I think this is a fundamental issue and this solves it in RequireJS quite neatly, with no risk. In-page code being a separate use case to post-page-load code, which should always be async.

If I write a module with require-cs, I immediately lose this benefit due to the AJAX call. But if it just checks one flag to provide sync AJAX that will solve this entirely.

The flag is created during a sync cycle and removed in the same cycle, so there is no chance of leakage into other requires.

Happy to discuss further, and thanks for taking the time to consider as always.
