### PR TITLE
Expose fetchText for other plugins' benefit; make safe with other plugins

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -133,6 +133,14 @@ define(['coffee-script'], function (CoffeeScript) {
         write: function (pluginName, name, write) {
             if (buildMap.hasOwnProperty(name)) {
                 var text = buildMap[name];
+                if (/\.coffee$/.test(name)) {
+                    //Trim off .coffee for writing back out the module name,
+                    //so that dependencies resolve correctly in the compiled
+                	//version.  Note that this still includes the pluginName,
+                	//so modules loaded with different plugins will still be
+                	//distinct.
+                    name = name.substring(0, name.length - 7);
+                }
                 write.asModule(pluginName + "!" + name, text);
             }
         },


### PR DESCRIPTION
Essentially, I wrote a css plugin as part of my jsProject base, and since you've put a fair bit of effort into making the fetchText() method from require-cs so nice, it's convenient to re-use that code to aid other plugins.

Additionally, if I have these two files as requirements in my project:

test.coffee
test.js

Then the current incarnation of require-cs will only load the first requirement, and substitute that module for the second request.  This is because the name of the loaded module does not include the ".coffee" extension, making it impossible for RequireJS to tell a difference.  Using the normalize() method seems to fix this; see commit in request.
