### PR TITLE
Fix Literate CoffeeScript detection

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -126,11 +126,12 @@ define(['coffee-script'], function (CoffeeScript) {
             // preserve existing logic with new literate coffeescript extensions (*.litcoffee or *.coffee.md).
             // if name passes check, use it, as-is. otherwise, behave as before, appending .coffee to the
             // requirejs binding.
-            var path = parentRequire.toUrl(/\.((lit)?coffee|coffee\.md)$/.test(name) ? name : name + '.coffee');
+            var fullName = /\.((lit)?coffee|coffee\.md)$/.test(name) ? name : name + '.coffee';
+            var path = parentRequire.toUrl(fullName);
             fetchText(path, function (text) {
                 // preserve existing logic. integrate new 'literate' compile flag with any requirejs configs.
                 var opts = config.CoffeeScript || {};
-                opts.literate = /\.(litcoffee|coffee\.md)$/.test(path);
+                opts.literate = /\.(litcoffee|coffee\.md)$/.test(fullName);
                 //Do CoffeeScript transform.
                 try {
                     text = CoffeeScript.compile(text, opts);


### PR DESCRIPTION
Current check fails if module path has query string.
We should check module name with extension instead of path.
