### PR TITLE
Use CoffeScript.helpers.* functions to detect CS and Literate CS files

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -126,12 +126,12 @@ define(['coffee-script'], function (CoffeeScript) {
             // preserve existing logic with new literate coffeescript extensions (*.litcoffee or *.coffee.md).
             // if name passes check, use it, as-is. otherwise, behave as before, appending .coffee to the
             // requirejs binding.
-            var fullName = /\.((lit)?coffee|coffee\.md)$/.test(name) ? name : name + '.coffee';
+            var fullName = CoffeeScript.helpers.isCoffee(name) ? name : name + '.coffee';
             var path = parentRequire.toUrl(fullName);
             fetchText(path, function (text) {
                 // preserve existing logic. integrate new 'literate' compile flag with any requirejs configs.
                 var opts = config.CoffeeScript || {};
-                opts.literate = /\.(litcoffee|coffee\.md)$/.test(fullName);
+                opts.literate = CoffeeScript.helpers.isLiterate(fullName);
                 //Do CoffeeScript transform.
                 try {
                     text = CoffeeScript.compile(text, opts);


### PR DESCRIPTION
CoffeeScript exposes two methods `isCoffee()` and `isLiterate()` to detect CS files.
We don't need to invent the wheel)

https://github.com/jashkenas/coffee-script/blob/master/lib/coffee-script/helpers.js#L181-L187
