### PR TITLE
Add "description" and "ignore" sections to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,16 @@
 {
   "name": "require-cs",
+  "description": "An AMD loader plugin for CoffeeScript",
   "version": "0.4.4",
   "dependencies": {
     "coffee-script": "https://raw.github.com/jashkenas/coffee-script/1.6.2/extras/coffee-script.js"
-  }
+  },
+  "ignore": [
+    "demo",
+    "tools",
+    ".*",
+    "coffee-script.js",
+    "demoserver.js",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
End user doesn't need `demo`, `tools` and other stuff.
