### PR TITLE
added optional support for node-source-map-support

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -13,92 +13,92 @@
 *  http://www.webtoolkit.info/
 *
 **/
- 
+
 var Base64 = {
- 
+
     // private property
     _keyStr : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
- 
+
     // public method for encoding
     encode : function (input) {
         var output = "";
         var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
         var i = 0;
- 
+
         input = Base64._utf8_encode(input);
- 
+
         while (i < input.length) {
- 
+
             chr1 = input.charCodeAt(i++);
             chr2 = input.charCodeAt(i++);
             chr3 = input.charCodeAt(i++);
- 
+
             enc1 = chr1 >> 2;
             enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
             enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
             enc4 = chr3 & 63;
- 
+
             if (isNaN(chr2)) {
                 enc3 = enc4 = 64;
             } else if (isNaN(chr3)) {
                 enc4 = 64;
             }
- 
+
             output = output +
             this._keyStr.charAt(enc1) + this._keyStr.charAt(enc2) +
             this._keyStr.charAt(enc3) + this._keyStr.charAt(enc4);
- 
+
         }
- 
+
         return output;
     },
- 
+
     // public method for decoding
     decode : function (input) {
         var output = "";
         var chr1, chr2, chr3;
         var enc1, enc2, enc3, enc4;
         var i = 0;
- 
+
         input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
- 
+
         while (i < input.length) {
- 
+
             enc1 = this._keyStr.indexOf(input.charAt(i++));
             enc2 = this._keyStr.indexOf(input.charAt(i++));
             enc3 = this._keyStr.indexOf(input.charAt(i++));
             enc4 = this._keyStr.indexOf(input.charAt(i++));
- 
+
             chr1 = (enc1 << 2) | (enc2 >> 4);
             chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
             chr3 = ((enc3 & 3) << 6) | enc4;
- 
+
             output = output + String.fromCharCode(chr1);
- 
+
             if (enc3 != 64) {
                 output = output + String.fromCharCode(chr2);
             }
             if (enc4 != 64) {
                 output = output + String.fromCharCode(chr3);
             }
- 
+
         }
- 
+
         output = Base64._utf8_decode(output);
- 
+
         return output;
- 
+
     },
- 
+
     // private method for UTF-8 encoding
     _utf8_encode : function (string) {
         string = string.replace(/\r\n/g,"\n");
         var utftext = "";
- 
+
         for (var n = 0; n < string.length; n++) {
- 
+
             var c = string.charCodeAt(n);
- 
+
             if (c < 128) {
                 utftext += String.fromCharCode(c);
             }
@@ -111,22 +111,22 @@ var Base64 = {
                 utftext += String.fromCharCode(((c >> 6) & 63) | 128);
                 utftext += String.fromCharCode((c & 63) | 128);
             }
- 
+
         }
- 
+
         return utftext;
     },
- 
+
     // private method for UTF-8 decoding
     _utf8_decode : function (utftext) {
         var string = "";
         var i = 0;
         var c = c1 = c2 = 0;
- 
+
         while ( i < utftext.length ) {
- 
+
             c = utftext.charCodeAt(i);
- 
+
             if (c < 128) {
                 string += String.fromCharCode(c);
                 i++;
@@ -142,26 +142,59 @@ var Base64 = {
                 string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
                 i += 3;
             }
- 
+
         }
- 
+
         return string;
     }
- 
+
 }
 
 define(['coffee-script'], function (CoffeeScript) {
     'use strict';
-    var fs, getXhr,
+    var fs, nodePath, getXhr,
         progIds = ['Msxml2.XMLHTTP', 'Microsoft.XMLHTTP', 'Msxml2.XMLHTTP.4.0'],
         fetchText = function () {
             throw new Error('Environment unsupported.');
         },
-        buildMap = {};
+        buildMap = {},
+        isNode = false,
+        sources = {},
+        sourceMaps = {};
 
     if (typeof process !== "undefined" &&
                process.versions &&
                !!process.versions.node) {
+        try {
+            require.nodeRequire('source-map-support').install({
+                retrieveFile: function(source) {
+                    return sources[source];
+                },
+                retrieveSourceMap: function(source) {
+                    var map = sourceMaps[source];
+                    if(map) {
+                        if(typeof map === 'string') {
+                            map = sourceMaps[source] = JSON.parse(map);
+                            map.sourceRoot = nodePath.dirname(source);
+                            map.sources[0] = nodePath.basename(source);
+                        }
+
+                        return {
+                            url: source,
+                            map: map
+                        };
+                    }
+                    return null;
+                }
+            });
+
+            isNode = true;
+            nodePath = require.nodeRequire('path');
+        }
+        catch(err) {
+            // Disable source-map-support on error.
+        }
+
         //Using special require.nodeRequire, something added by r.js.
         fs = require.nodeRequire('fs');
         fetchText = function (path, callback) {
@@ -294,7 +327,14 @@ define(['coffee-script'], function (CoffeeScript) {
                 //sourceURL trick, so skip it if enabled.
                 /*@if (@_jscript) @else @*/
                 if (!config.isBuild) {
-                    text += '\n//# sourceMappingURL=data:application/json;base64,' + Base64.encode(compiled.v3SourceMap || '') + '\n//# sourceURL=' + path;
+                    if(isNode) {
+                        text += '//@ sourceURL=' + path;
+                        sources[path] = text;
+                        sourceMaps[path] = compiled.v3SourceMap;
+                    }
+                    else {
+                        text += '\n//@ sourceMappingURL=data:application/json;base64,' + Base64.encode(compiled.v3SourceMap || '') + '\n//@ sourceURL=' + path;
+                    }
                 }
                 /*@end@*/
 
@@ -302,7 +342,7 @@ define(['coffee-script'], function (CoffeeScript) {
                 if (config.isBuild) {
                     buildMap[name] = text;
                 }
-                
+
                 load.fromText(name, text);
 
                 //Give result to load. Need to wait until the module


### PR DESCRIPTION
I added optional support for ```node-source-map-support``` when running under node.js and not performing a build. This allows stack traces to display the proper CoffeeScript line/column during development.

I also changed the comments for source maps from ```//#``` to ```//@``` since they are natively recognized by node.js. Without this modification the eval'd source files in the stack traces show up as ```<anonymous>```.

This requires my fork of [node-source-map-support](https://github.com/ddude/node-source-map-support) in order to work. I've made a [pull request](https://github.com/evanw/node-source-map-support/pull/24) for this.