### PR TITLE
Fixes allowing source mapping to work

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -277,8 +277,9 @@ define(['coffee-script'], function (CoffeeScript) {
                 opts.sourceMap = true;
                 opts.header = true;
                 opts.inline = true;
-                opts.sourceFiles = [name + opts.literate ? '' : '.coffee'];
-                opts.generatedFile = name + opts.literate ? '' : '.coffee';
+                opts.filename = fullName;
+                opts.sourceFiles = [name + (opts.literate ? '' : '.coffee')];
+                opts.generatedFile = name + (opts.literate ? '' : '.coffee');
 
                 var compiled;
                 //Do CoffeeScript transform.


### PR DESCRIPTION
- filename is a required option to compile()
- Parens around a ternary, since ('name' + false ? '' : '.coffee') evaluates to '', not 'name.coffee'

Tested in Chrome 33 and Firefox 24. Without the first fix, the compile() fails because it tries to split() filename, which is undefined. See compile() in coffee-script.coffee in the CS source.
