### PR TITLE
Line Numbers for Errors

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -300,10 +300,9 @@ define(['coffee-script'], function (CoffeeScript) {
                         else {
                             err.message += '-' + (loc.last_line + 1);
                         }
-
                     }
 
-                    err.message += ": " + msg;
+                    err.message += ': ' + msg;
                     throw err;
                 }
                 text = compiled.js;


### PR DESCRIPTION
Found myself wishing I had this, so here's a patch.  Hopefully the `location` object is present in all versions of CoffeeScript, but if not it's a simple conditional to fall back to the old error message.
