### PR TITLE
Remove extra function call

### DIFF
--- a/cs.js
+++ b/cs.js
@@ -321,13 +321,6 @@ define(['coffee-script'], function (CoffeeScript) {
                 }
                 
                 load.fromText(name, text);
-
-                //Give result to load. Need to wait until the module
-                //is fully parse, which will happen after this
-                //execution.
-                parentRequire([name], function (value) {
-                    load(value);
-                });
             });
         }
     };


### PR DESCRIPTION
There is no need to call require again since the core module do it itself here: https://github.com/jrburke/requirejs/blob/master/require.js#L1074

I've tested on `demo` and `demo-build` showcases and want to use it in my project.